### PR TITLE
fix abouts' link to projects page

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -15,7 +15,7 @@ import Navigation from '../components/Navigation.astro'
   		<h1 class="title-gradient">About CS Hub</h1>
   		<p>It all changed when the Alpha@Coders Nation attacked... Only the supreme coders, master of all code could stop them. But when the world needed them most, they vanished. Centuries have passed and we are slowly discovering the ancient techniques of code. Over the years, CS Hub was created to share these techniques so we can save the world.</p>
 		<p>CS Hub is a community made by computer science students for computer science students just like you. We like to discuss current tech events, new technologies, games, events, and share valuable resources for students. </p>
-		<p>One of our goals is to create multiple open source projects that we can contribute to! We share, discuss, and create projects for the benefit of us all. Whether you are a beginner, intermediate or a I don't know what I'm doing type of coder, you are welcome to learn, share, and contribute to our ongoing <a class="project-link" href="projects">projects</a>.</p>
+		<p>One of our goals is to create multiple open source projects that we can contribute to! We share, discuss, and create projects for the benefit of us all. Whether you are a beginner, intermediate or a I don't know what I'm doing type of coder, you are welcome to learn, share, and contribute to our ongoing <a class="project-link" href="/projects">projects</a>.</p>
 		
   	</main>
 </Layout>


### PR DESCRIPTION
Bottom of the Abouts page had a broken link to Projects. Added slash to fix it.