### PR TITLE
temporary fix for dark mode readers

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -14,6 +14,7 @@ const { title } = Astro.props;
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="generator" content={Astro.generator} />
+    <meta name="darkreader-lock" />
     <title>{title}</title>
   </head>
   <body>


### PR DESCRIPTION
Dark mode readers were making text disappear. Currently placed a darkreader-lock  to prevent it.